### PR TITLE
Workaround for smartcard issue since 3dc4e283dbcf296cbd2648c9277e015a…

### DIFF
--- a/channels/smartcard/client/smartcard_operations.c
+++ b/channels/smartcard/client/smartcard_operations.c
@@ -2149,6 +2149,7 @@ LONG smartcard_irp_device_control_call(SMARTCARD_DEVICE* smartcard, SMARTCARD_OP
 	smartcard_pack_common_type_header(smartcard, irp->output); /* CommonTypeHeader (8 bytes) */
 	smartcard_pack_private_type_header(smartcard, irp->output,
 	                                   objectBufferLength); /* PrivateTypeHeader (8 bytes) */
+	result = SCARD_S_SUCCESS;
 	Stream_Write_UINT32(irp->output, result); /* Result (4 bytes) */
 	Stream_SetPosition(irp->output, Stream_Length(irp->output));
 	return SCARD_S_SUCCESS;


### PR DESCRIPTION
…d4a74e71.

Prior to commit 3dc4e283dbcf296cbd2648c9277e015ad4a74e71 result has always been set to SCARD_S_SUCCESS by smartcard_pack_common_type_header() and smartcard_pack_private_type_header().
Since result has some real value there are issues with reading data from the smartcard reader.

Restoring hard-coded result = SCARD_S_SUCCESS until a solution is found.